### PR TITLE
Cleanups

### DIFF
--- a/test/test-cases/scale/saic/conftest.py
+++ b/test/test-cases/scale/saic/conftest.py
@@ -1,15 +1,8 @@
 import logging
 import pytest
 
-from dpugen import saigen
-from dpugen.saigen.confbase import ConfBase
-
-# import sys
-# sys.path.insert(0, '/sai-challenger/common')  # Needed for correct load_module
-
 from saichallenger.common.sai_dpu import SaiDpu
 from saichallenger.common.sai_environment import init_setup
-
 
 def pytest_addoption(parser):
     parser.addoption("--traffic", action="store_true", default=False, help="run tests with traffic")

--- a/test/test-cases/scale/saic/conftest.py
+++ b/test/test-cases/scale/saic/conftest.py
@@ -52,31 +52,31 @@ def dataplane(dataplane_session):
     dataplane_session.tearDown()
 
 
-@pytest.fixture(scope="session")
-def confgen():
+# @pytest.fixture(scope="session")
+# def confgen():
 
-    class SaiConfig(ConfBase):
+#     class SaiConfig(ConfBase):
 
-        def generate(self):
-            # Pass top-level params to sub-generators.
-            self.configs = [
-                saigen.vips.Vips(self.params_dict),
-                saigen.direction_lookup.DirectionLookup(self.params_dict),
-                saigen.acl_groups.AclGroups(self.params_dict),
-                saigen.vnets.Vnets(self.params_dict),
-                saigen.enis.Enis(self.params_dict),
-                saigen.address_maps.AddressMaps(self.params_dict),
-                saigen.outbound_routing.OutboundRouting(self.params_dict),
-                saigen.outbound_ca_to_pa.OutboundCaToPa(self.params_dict),
-                # saigen.inbound_routing.InboundRouting(self.params_dict),
-                # saigen.pa_validation.PaValidation(self.params_dict),
-            ]
+#         def generate(self):
+#             # Pass top-level params to sub-generators.
+#             self.configs = [
+#                 saigen.vips.Vips(self.params_dict),
+#                 saigen.direction_lookup.DirectionLookup(self.params_dict),
+#                 saigen.acl_groups.AclGroups(self.params_dict),
+#                 saigen.vnets.Vnets(self.params_dict),
+#                 saigen.enis.Enis(self.params_dict),
+#                 saigen.address_maps.AddressMaps(self.params_dict),
+#                 saigen.outbound_routing.OutboundRouting(self.params_dict),
+#                 saigen.outbound_ca_to_pa.OutboundCaToPa(self.params_dict),
+#                 # saigen.inbound_routing.InboundRouting(self.params_dict),
+#                 # saigen.pa_validation.PaValidation(self.params_dict),
+#             ]
 
-        def items(self, reverse=False):
-            result = []
-            for c in self.configs:
-                result.extend(c.items())
-            return result
+#         def items(self, reverse=False):
+#             result = []
+#             for c in self.configs:
+#                 result.extend(c.items())
+#             return result
 
-    return SaiConfig()
-    # return SaiConfig({}, saigen.simple_params.simple_params)
+#     return SaiConfig()
+#     # return SaiConfig({}, saigen.simple_params.simple_params)

--- a/test/test-cases/scale/saic/conftest.py
+++ b/test/test-cases/scale/saic/conftest.py
@@ -50,33 +50,3 @@ def dataplane(dataplane_session):
     dataplane_session.setUp()
     yield dataplane_session
     dataplane_session.tearDown()
-
-
-# @pytest.fixture(scope="session")
-# def confgen():
-
-#     class SaiConfig(ConfBase):
-
-#         def generate(self):
-#             # Pass top-level params to sub-generators.
-#             self.configs = [
-#                 saigen.vips.Vips(self.params_dict),
-#                 saigen.direction_lookup.DirectionLookup(self.params_dict),
-#                 saigen.acl_groups.AclGroups(self.params_dict),
-#                 saigen.vnets.Vnets(self.params_dict),
-#                 saigen.enis.Enis(self.params_dict),
-#                 saigen.address_maps.AddressMaps(self.params_dict),
-#                 saigen.outbound_routing.OutboundRouting(self.params_dict),
-#                 saigen.outbound_ca_to_pa.OutboundCaToPa(self.params_dict),
-#                 # saigen.inbound_routing.InboundRouting(self.params_dict),
-#                 # saigen.pa_validation.PaValidation(self.params_dict),
-#             ]
-
-#         def items(self, reverse=False):
-#             result = []
-#             for c in self.configs:
-#                 result.extend(c.items())
-#             return result
-
-#     return SaiConfig()
-#     # return SaiConfig({}, saigen.simple_params.simple_params)

--- a/test/test-cases/scale/saic/test_sai_vnet_inbound.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_inbound.py
@@ -114,7 +114,7 @@ TEST_VNET_INBOUND_CONFIG = {
 
 class TestSaiVnetInbound:
 
-    def test_vnet_inbound_create(self, confgen, dpu):
+    def test_vnet_inbound_create(self, dpu):
         """Test configuration create"""
 
         # confgen.mergeParams(TEST_VNET_INBOUND_CONFIG)
@@ -173,7 +173,7 @@ class TestSaiVnetInbound:
         print("\nVerifying packet...\n", vxlan_exp_pkt.__repr__())
         verify_packet(dataplane, vxlan_exp_pkt, 1)
 
-    def test_vnet_inbound_remove(self, confgen, dpu):
+    def test_vnet_inbound_remove(self, dpu):
         """Test configuration remove"""
 
         # confgen.mergeParams(TEST_VNET_INBOUND_CONFIG)

--- a/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
@@ -4,12 +4,6 @@ from pprint import pprint
 
 import pytest
 import saichallenger.dataplane.snappi.snappi_traffic_utils as stu
-from saichallenger.dataplane.ptf_testutils import (send_packet,
-                                                   simple_udp_packet,
-                                                   simple_vxlan_packet,
-                                                   verify_no_other_packets,
-                                                   verify_packet)
-
 import dash_helper.vnet2vnet_helper as dh
 
 current_file_dir = Path(__file__).parent
@@ -82,12 +76,10 @@ class TestSaiVnetOutbound:
     def test_create_vnet_config(self, dpu):
         """Generate and apply configuration"""
 
-        results = []
         conf = dpugen.sai.SaiConfig()
-        #sa.common_parse_args(conf)
         conf.mergeParams(TEST_VNET_OUTBOUND_CONFIG_SCALE)
         conf.generate()
-        result = [*dpu.process_commands( (conf.items()) )]
+        results = [*dpu.process_commands( (conf.items()) )]
 
     @pytest.mark.snappi
     def test_run_traffic_check_fixed_packets(self, dpu, dataplane):
@@ -136,4 +128,4 @@ class TestSaiVnetOutbound:
         
         cleanup_commands = [{'name': cmd['name'], 'op': 'remove'} for cmd in conf.items()]
         cleanup_commands = reversed(cleanup_commands)
-        result = [*dpu.process_commands(cleanup_commands)]
+        results = [*dpu.process_commands(cleanup_commands)]

--- a/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
@@ -1,4 +1,26 @@
-import json
+#!/usr/bin/python3
+#
+# Pytest case can be run as normal pytest or as standalone executable to dump configurations
+#
+# PyTest:
+# =======
+# run snappi-enabled tests using snappi dataplane (e.g. ixia-c pktgen)
+#   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_snappi.json -m snappi <this-filename> 
+# run PTF-enabled tests using snappi test fixture (e.g. ixia-c pktgen)
+#   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_snappi.json -m ptf <this-filename>
+# run PTF-enabled tests using PTF dataplane (e.g. scapy)
+#   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_ptf.json -m ptf <this-filename>
+#   
+# NOT SUPPORTED: run snappi-capable tests using PTF dataplane (PTF can't support snappi at this writing)
+#   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_ptf.json -m snappi <this-filename>
+#   
+# Standalone:
+# <this-filename> -h  # Print help
+# <this-filename> -a  # Dump create & remove SAI records as JSON to stdout
+# <this-filename> -c  # Dump create SAI records as JSON to stdout
+# <this-filename> -r  # Dump create SAI records as JSON to stdout
+#
+import json, argparse
 from pathlib import Path
 from pprint import pprint
 
@@ -70,16 +92,31 @@ TEST_VNET_OUTBOUND_CONFIG_SCALE = {
 }
 
 
-
 class TestSaiVnetOutbound:
-
-    def test_create_vnet_config(self, dpu):
-        """Generate and apply configuration"""
-
+    def make_create_vnet_config(self):
+        """ Generate a configuration
+            returns iterator (generator) of SAI records
+        """
         conf = dpugen.sai.SaiConfig()
         conf.mergeParams(TEST_VNET_OUTBOUND_CONFIG_SCALE)
         conf.generate()
-        results = [*dpu.process_commands( (conf.items()) )]
+        return conf.items()
+
+    def make_remove_vnet_config(self):
+        """ Generate a configuration to remove entries
+            returns iterator (generator) of SAI records
+        """
+        cleanup_commands = [{'name': cmd['name'], 'op': 'remove'} for cmd in self.make_create_vnet_config()]
+        cleanup_commands = reversed(cleanup_commands)
+        for cmd in cleanup_commands:
+            yield cmd
+        return
+
+    @pytest.mark.ptf
+    @pytest.mark.snappi
+    def test_create_vnet_config(self, dpu):
+        """Generate and apply configuration"""
+        results = [*dpu.process_commands( (self.make_create_vnet_config()) )]
 
     @pytest.mark.snappi
     def test_run_traffic_check_fixed_packets(self, dpu, dataplane):
@@ -117,15 +154,35 @@ class TestSaiVnetOutbound:
                                                                 name="Custom flow group", show=True)[0],
                     "Test", timeout_seconds=test_duration + 1)
 
+    @pytest.mark.ptf
+    @pytest.mark.snappi
     def test_remove_vnet_config(self, dpu, dataplane):
         """
         Generate and remove configuration
         We generate configuration on remove stage as well to avoid storing giant objects in memory.
         """
-        conf = dpugen.sai.SaiConfig()
-        conf.mergeParams(TEST_VNET_OUTBOUND_CONFIG_SCALE)
-        conf.generate()
-        
-        cleanup_commands = [{'name': cmd['name'], 'op': 'remove'} for cmd in conf.items()]
-        cleanup_commands = reversed(cleanup_commands)
-        results = [*dpu.process_commands(cleanup_commands)]
+        results = [*dpu.process_commands( (self.make_remove_vnet_config()) )]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='DASH SAI Config Generator for vnet outbound')
+    parser.add_argument('-a', action='store_true', help='Generate all SAI records as JSON to stdout')
+    parser.add_argument('-c', action='store_true', help='Generate "create" SAI records as JSON to stdout')
+    parser.add_argument('-r', action='store_true', help='Generate "remove"" SAI records as JSON to stdout')
+
+    args = parser.parse_args()
+
+    if not args.a and not args.c and not args.r:
+        # must provide at least one flag
+        print ("\n*** Please specify at least one option flag from [acr] to generate output ***\n", file=sys.stderr)
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    if args.a or args.c:
+        print(json.dumps([cmd for cmd in (TestSaiVnetOutbound().make_create_vnet_config())],
+                         indent=2))
+
+    if args.a or args.r:
+        print(json.dumps([cmd for cmd in (TestSaiVnetOutbound().make_remove_vnet_config())],
+                         indent=2))
+

--- a/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
@@ -1,10 +1,14 @@
 #!/usr/bin/python3
 #
-# Pytest case can be run as normal pytest or as standalone executable to dump configurations
+# Pytest case which can be run as a normal pytest or as standalone executable, to dump generated configurations.
 #
 # PyTest:
 # =======
-# run snappi-enabled tests using snappi dataplane (e.g. ixia-c pktgen)
+# 
+# Note, not all tests involve sending traffic, for example setup/teardown of DUT configurations,
+# so PTF or snappi may not be relevant. Such cases are often marked for both dataplanes.
+#
+# run snappi-enabled tests using snappi dataplane (e.g. ixia-c pktgen):
 #   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_snappi.json -m snappi <this-filename> 
 # run PTF-enabled tests using snappi test fixture (e.g. ixia-c pktgen)
 #   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_snappi.json -m ptf <this-filename>
@@ -13,7 +17,7 @@
 #   
 # NOT SUPPORTED: run snappi-capable tests using PTF dataplane (PTF can't support snappi at this writing)
 #   PYTHONPATH=. pytest -sv --setup sai_dpu_client_server_ptf.json -m snappi <this-filename>
-#   
+#
 # Standalone:
 # <this-filename> -h  # Print help
 # <this-filename> -a  # Dump create & remove SAI records as JSON to stdout

--- a/test/test-cases/scale/saic/test_sai_vnet_outbound_simple.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_outbound_simple.py
@@ -118,17 +118,14 @@ TEST_VNET_OUTBOUND_CONFIG = {
 }
 
 
+@pytest.mark.ptf
+@pytest.mark.snappi
 class TestSaiVnetOutbound:
 
-    def test_vnet_inbound_simple_create(self, confgen, dpu):
+    @pytest.mark.ptf
+    @pytest.mark.snappi
+    def test_vnet_inbound_simple_create(self, dpu):
         """Generate and apply configuration"""
-
-        # confgen.mergeParams(TEST_VNET_OUTBOUND_CONFIG)
-        # confgen.generate()
-        # results = []
-        # for item in confgen.items():
-        #     pprint(item)
-        #     results.append(dpu.command_processor.process_command(item))
 
         with (current_file_dir / 'vnet_outbound_setup_commands_simple.json').open(mode='r') as config_file:
             setup_commands = json.load(config_file)
@@ -275,16 +272,10 @@ class TestSaiVnetOutbound:
                                                                 name="Custom flow group", show=True)[0],
                     "Test", timeout_seconds=test_duration + 1)
 
-    def test_vnet_inbound_simple_remove(self, confgen, dpu):
+    @pytest.mark.ptf
+    @pytest.mark.snappi
+    def test_vnet_inbound_simple_remove(self, dpu):
         """Verify configuration removal"""
-
-        # confgen.mergeParams(TEST_VNET_OUTBOUND_CONFIG)
-        # confgen.generate()
-        # results = []
-        # for item in confgen.items():
-        #     item['op'] = 'remove'
-        #     pprint(item)
-        #     results.append(dpu.command_processor.process_command(item))
 
         with (current_file_dir / 'vnet_outbound_setup_commands_simple.json').open(mode='r') as config_file:
             setup_commands = json.load(config_file)


### PR DESCRIPTION
Vinod, please check out the additional changes, merge if acceptable and add the following comments to your PR 
https://github.com/Azure/DASH/pull/295, thanks:
- remove obsolete PyTest test-fixture setup for `confgen()`, the updated `dpugen` package has a constructor rendering this fixture redundant; remove references to it in test cases
- cleanup commented-out code and unused imports
- add Pytest markers `snappi` and `ptf` for create and remove test cases to ensure running a subset of tests performs setup and teardown